### PR TITLE
feat: GET /api/system — Mac + Hetzner metrics

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,10 @@
+import asyncio
+from typing import Any
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+
+from app.system import get_mac_metrics, get_hetzner_metrics
 
 app = FastAPI(title="Ops Dashboard", version="0.1.0")
 
@@ -15,3 +20,24 @@ app.add_middleware(
 @app.get("/api/health")
 async def health() -> dict:
     return {"status": "ok"}
+
+
+@app.get("/api/system")
+async def system_metrics() -> dict[str, Any]:
+    """Return Mac + Hetzner system metrics."""
+    mac = await asyncio.get_event_loop().run_in_executor(None, get_mac_metrics)
+
+    hetzner: dict[str, Any] | None = None
+    hetzner_error: str | None = None
+    try:
+        hetzner = await asyncio.get_event_loop().run_in_executor(
+            None, get_hetzner_metrics
+        )
+    except Exception as exc:
+        hetzner_error = str(exc)
+
+    return {
+        "mac": mac,
+        "hetzner": hetzner,
+        "hetzner_error": hetzner_error,
+    }


### PR DESCRIPTION
## Summary

- Adds `GET /api/system` endpoint returning structured JSON with Mac and Hetzner server metrics
- **Mac metrics** (via `psutil`): `cpu_percent`, `virtual_memory`, `disk_usage`, `sensors_temperatures`
- **Hetzner metrics** (via SSH/`paramiko` → `user3@94.130.65.86:2203`): parses `top -bn1` (CPU/mem %), `df -h` (filesystems), `docker ps --format json` (container list)
- Hetzner SSH failures are non-fatal: the response still includes Mac metrics with a `hetzner_error` field explaining the failure

## Response shape

```json
{
  "mac": {
    "cpu_percent": 12.3,
    "memory": {"total_gb": 16.0, "used_gb": 9.4, "percent": 58.7},
    "disk": {"total_gb": 500.0, "used_gb": 210.0, "percent": 42.0},
    "temperatures": {"CPU die": 51.0}
  },
  "hetzner": {
    "cpu_percent": 4.2,
    "memory_percent": 61.0,
    "disk": {"filesystem": "/dev/sda1", "size": "200G", "used": "80G", "avail": "110G", "use_percent": "42%", "mount": "/"},
    "filesystems": [...],
    "containers": [...],
    "container_count": 5
  },
  "hetzner_error": null
}
```

## Test plan

- [ ] `GET /api/system` returns 200 with `mac` block populated
- [ ] Mac `cpu_percent`, `memory.percent`, `disk.percent` are reasonable numbers
- [ ] When SSH is reachable, `hetzner` block is populated and `hetzner_error` is null
- [ ] When SSH is unreachable, `mac` block still present and `hetzner_error` contains the error message

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)