### PR TITLE
feat: GET /api/kanban — GitHub issues/PRs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,10 @@
-from fastapi import FastAPI
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+
+from app.kanban import fetch_kanban_cards
 
 app = FastAPI(title="Ops Dashboard", version="0.1.0")
 
@@ -11,7 +16,19 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+_executor = ThreadPoolExecutor(max_workers=4)
+
 
 @app.get("/api/health")
 async def health() -> dict:
     return {"status": "ok"}
+
+
+@app.get("/api/kanban")
+async def kanban() -> list[dict]:
+    loop = asyncio.get_event_loop()
+    try:
+        cards = await loop.run_in_executor(_executor, fetch_kanban_cards)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    return cards


### PR DESCRIPTION
## Summary

- Adds `app/kanban.py`: fetches issues + PRs from configured repos via `gh` CLI subprocess and categorizes them into kanban columns
- Adds `app/main.py`: FastAPI app (CORS, `/api/health`, `/api/kanban`) running gh calls in a thread pool executor
- Adds `requirements.txt`: fastapi, uvicorn, psutil, paramiko

## Column logic

| Column | Condition |
|--------|-----------|
| `done` | Issue state = CLOSED |
| `blocked` | Has `blocked` label |
| `review` | Has a linked open PR (or is a standalone open PR) |
| `progress` | Has `in-progress` label or has assignees |
| `backlog` | Everything else |

## Card schema

```json
{
  "id": "owner/repo#123",
  "title": "...",
  "column": "backlog|progress|review|done|blocked",
  "tags": ["feat", "fix"],
  "pr_url": "https://github.com/.../pull/7",
  "agent": "username",
  "timestamp": "2026-03-22T...",
  "url": "https://github.com/.../issues/123"
}
```

## Configuration

Set `KANBAN_REPOS=owner/repo1,owner/repo2` to override repos (defaults to `ddfeyes/ops-dashboard,ddfeyes/svc-dash`).

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)