### PR TITLE
feat: GET /api/usage — Anthropic API usage tracking

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.system import get_mac_metrics, get_hetzner_metrics
+from app.usage import get_usage
 
 app = FastAPI(title="Ops Dashboard", version="0.1.0")
 
@@ -41,3 +42,9 @@ async def system_metrics() -> dict[str, Any]:
         "hetzner": hetzner,
         "hetzner_error": hetzner_error,
     }
+
+
+@app.get("/api/usage")
+async def api_usage() -> dict[str, Any]:
+    """Return Anthropic API usage parsed from local Claude Code session logs."""
+    return await asyncio.get_event_loop().run_in_executor(None, get_usage)


### PR DESCRIPTION
## Summary

- Adds `GET /api/usage` endpoint to the FastAPI backend
- Parses local Claude Code session logs (`~/.claude/projects/**/*.jsonl`) to aggregate token usage
- Returns `current_session_pct`, `weekly_all_pct`, `weekly_sonnet_pct`, and weekly reset time

## Implementation

**`app/usage.py`** — core logic:
- Scans `~/.claude/projects/` for JSONL session files
- Parses `message.usage` from assistant entries (input/output/cache tokens)
- Current session = most recently modified JSONL file
- Weekly = all files modified this ISO week, filtered by entry timestamp
- Breaks down usage by model so Sonnet-specific percentage can be computed
- Token limits configurable via `SESSION_TOKEN_LIMIT`, `WEEKLY_ALL_TOKEN_LIMIT`, `WEEKLY_SONNET_TOKEN_LIMIT` env vars

**`app/main.py`** — wires in the new route via `run_in_executor` (non-blocking).

## Response shape

```json
{
  "current_session": { "input_tokens": 45, "output_tokens": 11833, "total_tokens": 11878, "by_model": {...} },
  "current_session_pct": 5.9,
  "weekly_all": { "total_tokens": 55783, "sonnet_tokens": 52067, "by_model": {...} },
  "weekly_all_pct": 0.6,
  "weekly_sonnet_pct": 0.7,
  "reset_times": { "weekly": "2026-03-30T00:00:00+00:00" },
  "limits": { "session_token_limit": 200000, ... },
  "source": "claude_code_local_logs"
}
```

## Test plan

- [ ] `GET /api/usage` returns 200 with expected keys
- [ ] `current_session_pct` reflects real token count from most recent JSONL
- [ ] `weekly_*_pct` reflects aggregated weekly usage
- [ ] Endpoint is non-blocking (uses `run_in_executor`)
- [ ] No new dependencies required (stdlib only)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)