### PR TITLE
feat: integrate all M1 endpoints — kanban, agents, system, usage

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,10 +1,18 @@
+"""Ops Dashboard — FastAPI backend with all M1 endpoints."""
+
+from __future__ import annotations
+
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.system import get_mac_metrics, get_hetzner_metrics
+from app.agents import get_ao_sessions, get_openclaw_agents
+from app.kanban import fetch_kanban_cards
+from app.system import get_hetzner_metrics, get_mac_metrics
+from app.usage import get_usage
 
 app = FastAPI(title="Ops Dashboard", version="0.1.0")
 
@@ -16,23 +24,43 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+_executor = ThreadPoolExecutor(max_workers=4)
+
 
 @app.get("/api/health")
 async def health() -> dict:
     return {"status": "ok"}
 
 
+@app.get("/api/kanban")
+async def kanban() -> list[dict]:
+    loop = asyncio.get_event_loop()
+    try:
+        cards = await loop.run_in_executor(_executor, fetch_kanban_cards)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return cards
+
+
+@app.get("/api/agents")
+async def agents() -> dict[str, Any]:
+    """Return AO sessions and OpenClaw agent list."""
+    loop = asyncio.get_event_loop()
+    sessions = await loop.run_in_executor(_executor, get_ao_sessions)
+    agent_list = await loop.run_in_executor(_executor, get_openclaw_agents)
+    return {"sessions": sessions, "agents": agent_list}
+
+
 @app.get("/api/system")
 async def system_metrics() -> dict[str, Any]:
     """Return Mac + Hetzner system metrics."""
-    mac = await asyncio.get_event_loop().run_in_executor(None, get_mac_metrics)
+    loop = asyncio.get_event_loop()
+    mac = await loop.run_in_executor(_executor, get_mac_metrics)
 
     hetzner: dict[str, Any] | None = None
     hetzner_error: str | None = None
     try:
-        hetzner = await asyncio.get_event_loop().run_in_executor(
-            None, get_hetzner_metrics
-        )
+        hetzner = await loop.run_in_executor(_executor, get_hetzner_metrics)
     except Exception as exc:
         hetzner_error = str(exc)
 
@@ -41,3 +69,10 @@ async def system_metrics() -> dict[str, Any]:
         "hetzner": hetzner,
         "hetzner_error": hetzner_error,
     }
+
+
+@app.get("/api/usage")
+async def usage() -> dict[str, Any]:
+    """Return Anthropic API usage from local Claude Code session logs."""
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(_executor, get_usage)


### PR DESCRIPTION
## Summary

Integrates all four M1 backend API endpoints into a unified `main.py`.

All module files (`kanban.py`, `agents.py`, `system.py`, `usage.py`) are already on `main` from prior merges. This PR wires them all into the FastAPI app.

## Endpoints
- `GET /api/health` ✅ (existing)
- `GET /api/kanban` ✅ GitHub issues/PRs categorized into Kanban columns
- `GET /api/agents` ✅ AO sessions + OpenClaw agent list
- `GET /api/system` ✅ Mac + Hetzner metrics (already merged via #7)
- `GET /api/usage` ✅ Anthropic token usage from Claude Code session logs

## Changes
- Unified `main.py` with all routes
- ThreadPoolExecutor for concurrent blocking calls
- Clean imports from dedicated modules

Closes #2 #3 #4 #5

Supersedes: #8 #9 #10