### PR TITLE
fix: apply Masami M1 review fixes (6 items)

### DIFF
--- a/app/agents.py
+++ b/app/agents.py
@@ -72,12 +72,7 @@ def get_openclaw_agents() -> list[dict[str, Any]]:
     agents = []
     for agent in agent_list:
         identity = agent.get("identity", {})
-        model = agent.get("model") or (
-            agent.get("agents", {})
-            .get("defaults", {})
-            .get("model", {})
-            .get("primary")
-        )
+        model = agent.get("model")
         agents.append(
             {
                 "id": agent.get("id"),

--- a/app/main.py
+++ b/app/main.py
@@ -18,13 +18,21 @@ app = FastAPI(title="Ops Dashboard", version="0.1.0")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
+    allow_origins=[
+        "http://localhost:3000",
+        "https://ops-dashboard.111miniapp.com",
+    ],
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
 _executor = ThreadPoolExecutor(max_workers=4)
+
+
+@app.on_event("shutdown")
+async def _shutdown() -> None:
+    _executor.shutdown(wait=False)
 
 
 @app.get("/api/health")
@@ -34,7 +42,7 @@ async def health() -> dict:
 
 @app.get("/api/kanban")
 async def kanban() -> list[dict]:
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     try:
         cards = await loop.run_in_executor(_executor, fetch_kanban_cards)
     except Exception as exc:
@@ -45,24 +53,32 @@ async def kanban() -> list[dict]:
 @app.get("/api/agents")
 async def agents() -> dict[str, Any]:
     """Return AO sessions and OpenClaw agent list."""
-    loop = asyncio.get_event_loop()
-    sessions = await loop.run_in_executor(_executor, get_ao_sessions)
-    agent_list = await loop.run_in_executor(_executor, get_openclaw_agents)
+    loop = asyncio.get_running_loop()
+    sessions, agent_list = await asyncio.gather(
+        loop.run_in_executor(_executor, get_ao_sessions),
+        loop.run_in_executor(_executor, get_openclaw_agents),
+    )
     return {"sessions": sessions, "agents": agent_list}
 
 
 @app.get("/api/system")
 async def system_metrics() -> dict[str, Any]:
     """Return Mac + Hetzner system metrics."""
-    loop = asyncio.get_event_loop()
-    mac = await loop.run_in_executor(_executor, get_mac_metrics)
+    loop = asyncio.get_running_loop()
+    results = await asyncio.gather(
+        loop.run_in_executor(_executor, get_mac_metrics),
+        loop.run_in_executor(_executor, get_hetzner_metrics),
+        return_exceptions=True,
+    )
+    mac = results[0]
+    hetzner_result = results[1]
 
     hetzner: dict[str, Any] | None = None
     hetzner_error: str | None = None
-    try:
-        hetzner = await loop.run_in_executor(_executor, get_hetzner_metrics)
-    except Exception as exc:
-        hetzner_error = str(exc)
+    if isinstance(hetzner_result, BaseException):
+        hetzner_error = str(hetzner_result)
+    else:
+        hetzner = hetzner_result
 
     return {
         "mac": mac,
@@ -74,5 +90,5 @@ async def system_metrics() -> dict[str, Any]:
 @app.get("/api/usage")
 async def usage() -> dict[str, Any]:
     """Return Anthropic API usage from local Claude Code session logs."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     return await loop.run_in_executor(_executor, get_usage)

--- a/app/system.py
+++ b/app/system.py
@@ -3,15 +3,16 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from typing import Any
 
 import paramiko
 import psutil
 
-HETZNER_HOST = "94.130.65.86"
-HETZNER_PORT = 2203
-HETZNER_USER = "user3"
+HETZNER_HOST = os.getenv("HETZNER_HOST", "94.130.65.86")
+HETZNER_PORT = int(os.getenv("HETZNER_PORT", "2203"))
+HETZNER_USER = os.getenv("HETZNER_USER", "user3")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to PRs #7 and #11 (M1 Backend API). Applies all 6 fixes from Masami's APPROVE_WITH_FIXES review.

## Changes

### 1. CORS hardening (`main.py`)
- Replaced `allow_origins=["*"]` with explicit origins:
  `["http://localhost:3000", "https://ops-dashboard.111miniapp.com"]`
- Set `allow_credentials=False` (no cookies needed)

### 2. `asyncio.get_running_loop()` (`main.py`)
- Replaced all 4 uses of deprecated `asyncio.get_event_loop()`
- Affects: `/api/kanban`, `/api/agents`, `/api/system`, `/api/usage`

### 3. Parallel execution via `asyncio.gather()` (`main.py`)
- `/api/agents`: gather `get_ao_sessions` + `get_openclaw_agents` in parallel
- `/api/system`: gather `get_mac_metrics` + `get_hetzner_metrics` in parallel (`return_exceptions=True`)
- Fixes ~25s sequential latency on `/api/system`

### 4. Remove broken fallback in `agents.py`
- Removed `agent.get("agents", {}).get("defaults", ...)...` — that path doesn't exist on individual agent dicts

### 5. Executor shutdown on teardown (`main.py`)
- Added `@app.on_event("shutdown")` handler that calls `_executor.shutdown(wait=False)`

### 6. SSH config via env vars (`system.py`)
- `HETZNER_HOST`, `HETZNER_PORT`, `HETZNER_USER` now read from env with hardcoded defaults as fallback

## Related
- Masami review of PRs #7, #11
- Closes M1 (APPROVE_WITH_FIXES → DONE)