### PR TITLE
fix: metric-value visibility — flex row layout (Masami major fix)

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -585,24 +585,24 @@
       letter-spacing: 0.4px;
       font-weight: 500;
     }
-    .metric-pct {
-      font-size: 12px;
-      font-weight: 600;
-      font-family: "JetBrains Mono", Consolas, monospace;
-    }
+
     .metric-value {
-      position: absolute;
-      right: 6px;
-      top: 50%;
-      transform: translateY(-50%);
+      flex-shrink: 0;
       font-size: 10px;
       font-weight: 600;
       font-family: "JetBrains Mono", Consolas, monospace;
-      pointer-events: none;
-      opacity: 0.85;
-      text-shadow: 0 0 4px rgba(0,0,0,0.8);
+      min-width: 36px;
+      text-align: right;
+      opacity: 0.9;
+      line-height: 1;
+    }
+    .metric-bar-outer {
+      display: flex;
+      align-items: center;
+      gap: 8px;
     }
     .metric-bar-wrap {
+      flex: 1;
       height: 6px;
       background: var(--border);
       border-radius: 3px;
@@ -1085,13 +1085,12 @@
         <div class="metric-row">
           <div class="metric-label-row">
             <span class="metric-label">${escHtml(label)}</span>
-            <span class="metric-pct ${cls}">${pct.toFixed(1)}%</span>
           </div>
-          <div style="position:relative;">
+          <div class="metric-bar-outer">
             <div class="metric-bar-wrap">
               <div class="metric-bar ${cls}" style="width:${w}%"></div>
             </div>
-            <span class="metric-value mono ${cls}">${pct.toFixed(1)}%</span>
+            <span class="metric-value ${cls}">${pct.toFixed(1)}%</span>
           </div>
           ${detailHtml}
         </div>`;


### PR DESCRIPTION
**Root cause:** `.metric-bar-wrap` has `height:6px` + `overflow:hidden`, clipping the `position:absolute` percentage span regardless of its `top/transform` values.

**Fix:** replaced `position:absolute` layout with a flex row:
```
.metric-bar-outer  { display:flex; align-items:center; gap:8px; }
.metric-bar-wrap   { flex:1; height:6px; overflow:hidden; ... }  ← bar grows
.metric-value      { flex-shrink:0; min-width:36px; text-align:right; ... }  ← always visible sibling
```

**Verified visually** — screenshot confirms CPU/Memory/Disk percentages render clearly to the right of each bar at correct color.

**NIT (containers in renderServerMetrics):** already a non-issue — `renderServerMetrics()` only renders the 3 metric bars; containers are exclusively in `renderContainersPanel()`. No code change needed.