### PR TITLE
fix: use env_file for OPENCLAW vars, remove stale hardcoded JSON (#41)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     image: ops-dashboard:latest
     container_name: ops-dashboard
     restart: unless-stopped
+    env_file:
+      - ops-dashboard.env
     ports:
       - "8090:8090"
     environment:
@@ -14,7 +16,6 @@ services:
       - SESSION_TOKEN_LIMIT=200000
       - WEEKLY_ALL_TOKEN_LIMIT=10000000
       - WEEKLY_SONNET_TOKEN_LIMIT=7500000
-      - OPENCLAW_AGENTS_JSON=[{"id":"lain","name":"lain","emoji":null,"model":"anthropic/claude-opus-4-6","workspace":"/Users/aivan/agents/lain"},{"id":"the-wired","name":"The Wired","emoji":null,"model":"anthropic/claude-sonnet-4-6","workspace":"/Users/aivan/agents/the-wired"},{"id":"navi","name":"NAVI","emoji":null,"model":"anthropic/claude-sonnet-4-6","workspace":"/Users/aivan/agents/navi"},{"id":"psyche","name":"Psyche","emoji":null,"model":"anthropic/claude-sonnet-4-6","workspace":"/Users/aivan/agents/psyche"},{"id":"protocol7","name":"Protocol7","emoji":null,"model":"anthropic/claude-sonnet-4-6","workspace":"/Users/aivan/agents/protocol7"},{"id":"touko","name":"Touko Yonera","emoji":null,"model":"anthropic/claude-sonnet-4-6","workspace":"/Users/aivan/agents/touko"},{"id":"masami","name":"Masami Eiri","emoji":null,"model":"anthropic/claude-sonnet-4-6","workspace":"/Users/aivan/agents/masami"},{"id":"mika","name":"Mika Iwakura","emoji":null,"model":"anthropic/claude-sonnet-4-6","workspace":"/Users/aivan/agents/mika"},{"id":"ops-dashboard","name":"Fragment ops-dashboard","emoji":null,"model":"anthropic/claude-sonnet-4-6","workspace":"/Users/aivan/ops-dashboard"},{"id":"fragment-slot-01","name":"Fragment Slot 01","emoji":null,"model":"anthropic/claude-sonnet-4-6","workspace":"/Users/aivan/agents/fragments/slot-01"},{"id":"fragment-slot-02","name":"Fragment Slot 02","emoji":null,"model":"anthropic/claude-sonnet-4-6","workspace":"/Users/aivan/agents/fragments/slot-02"},{"id":"fragment-slot-03","name":"Fragment Slot 03","emoji":null,"model":"anthropic/claude-sonnet-4-6","workspace":"/Users/aivan/agents/fragments/slot-03"},{"id":"fragment-slot-04","name":"Fragment Slot 04","emoji":null,"model":"anthropic/claude-sonnet-4-6","workspace":"/Users/aivan/agents/fragments/slot-04"},{"id":"fragment-slot-05","name":"Fragment Slot 05","emoji":null,"model":"anthropic/claude-sonnet-4-6","workspace":"/Users/aivan/agents/fragments/slot-05"},{"id":"fragment-slot-06","name":"Fragment Slot 06","emoji":null,"model":"anthropic/claude-sonnet-4-6","workspace":"/Users/aivan/agents/fragments/slot-06"},{"id":"fragment-slot-07","name":"Fragment Slot 07","emoji":null,"model":"anthropic/claude-sonnet-4-6","workspace":"/Users/aivan/agents/fragments/slot-07"},{"id":"fragment-slot-08","name":"Fragment Slot 08","emoji":null,"model":"anthropic/claude-sonnet-4-6","workspace":"/Users/aivan/agents/fragments/slot-08"},{"id":"fragment-slot-09","name":"Fragment Slot 09","emoji":null,"model":"anthropic/claude-sonnet-4-6","workspace":"/Users/aivan/agents/fragments/slot-09"},{"id":"fragment-slot-10","name":"Fragment Slot 10","emoji":null,"model":"anthropic/claude-sonnet-4-6","workspace":"/Users/aivan/agents/fragments/slot-10"}]
     volumes:
       - ./static:/app/static:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
Closes #41

Removes hardcoded stale /Users/aivan/ paths from OPENCLAW_AGENTS_JSON in docker-compose.yml environment section. Adds env_file directive so Hetzner's ops-dashboard.env provides the correct Linux paths and agent status at runtime.