### PR TITLE
fix: agent active threshold 5min → 15min in push-env.sh (#57)

### DIFF
--- a/scripts/push-env.sh
+++ b/scripts/push-env.sh
@@ -27,7 +27,7 @@ for agent_dir in os.listdir(sessions_base):
         if last_ms:
             last_iso = datetime.fromtimestamp(last_ms/1000, tz=timezone.utc).isoformat()
             age_secs = now - last_ms/1000
-            result[agent_dir] = {"status": "active" if age_secs < 300 else "idle", "last_seen_iso": last_iso}
+            result[agent_dir] = {"status": "active" if age_secs < 900 else "idle", "last_seen_iso": last_iso}
     except Exception:
         pass
 print(json.dumps(result, separators=(',', ':')))


### PR DESCRIPTION
Closes #57

Raises the active status threshold from 300s (5 min) to 900s (15 min). Agents with 30-minute heartbeat cycles no longer incorrectly show idle during active periods.