### PR TITLE
feat: OpenClaw Cron Jobs panel (#59)

### DIFF
--- a/app/crons.py
+++ b/app/crons.py
@@ -1,0 +1,55 @@
+"""OpenClaw cron job status from injected env var."""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+OPENCLAW_GATEWAY_CRONS_JSON = os.getenv("OPENCLAW_GATEWAY_CRONS_JSON", "")
+
+
+def get_crons() -> list[dict[str, Any]]:
+    """Parse cron job data from OPENCLAW_GATEWAY_CRONS_JSON env var."""
+    raw = OPENCLAW_GATEWAY_CRONS_JSON.strip()
+    if not raw:
+        return []
+    try:
+        data = json.loads(raw)
+        jobs = data if isinstance(data, list) else data.get("jobs", [])
+        result = []
+        for j in jobs:
+            state = j.get("state", {})
+            sched = j.get("schedule", {})
+            interval_ms = sched.get("everyMs", 0)
+            interval_min = round(interval_ms / 60000) if interval_ms else None
+            last_run_ms = state.get("lastRunAtMs", 0)
+            next_run_ms = state.get("nextRunAtMs", 0)
+            last_run_iso = (
+                datetime.fromtimestamp(last_run_ms / 1000, tz=timezone.utc).isoformat()
+                if last_run_ms
+                else None
+            )
+            next_run_iso = (
+                datetime.fromtimestamp(next_run_ms / 1000, tz=timezone.utc).isoformat()
+                if next_run_ms
+                else None
+            )
+            result.append(
+                {
+                    "id": j.get("id"),
+                    "name": j.get("name", ""),
+                    "agent": j.get("agentId", ""),
+                    "enabled": j.get("enabled", True),
+                    "interval_min": interval_min,
+                    "last_run": last_run_iso,
+                    "next_run": next_run_iso,
+                    "last_status": state.get("lastRunStatus", "unknown"),
+                    "last_duration_ms": state.get("lastDurationMs", 0),
+                    "consecutive_errors": state.get("consecutiveErrors", 0),
+                }
+            )
+        # Sort by last_run descending (most recent first)
+        return sorted(result, key=lambda x: x.get("last_run") or "", reverse=True)
+    except Exception:
+        return []

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from app.agents import get_ao_sessions, get_openclaw_agents
+from app.crons import get_crons
 from app.kanban import fetch_kanban_cards
 from app.system import get_hetzner_metrics, get_mac_metrics, get_server_metrics
 from app.usage import get_usage
@@ -164,3 +165,10 @@ async def usage() -> dict[str, Any]:
     """Return Anthropic API usage from local Claude Code session logs."""
     loop = asyncio.get_running_loop()
     return await loop.run_in_executor(_executor, get_usage)
+
+
+@app.get("/api/crons")
+async def crons() -> list[dict[str, Any]]:
+    """Return OpenClaw cron job status."""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_executor, get_crons)

--- a/static/index.html
+++ b/static/index.html
@@ -87,7 +87,7 @@
     .dashboard-grid {
       display: grid;
       grid-template-columns: 1fr 1fr;
-      grid-template-rows: 1fr 1fr;
+      grid-template-rows: 1fr 1fr auto;
       gap: 12px;
       height: calc(100vh - 48px);
       padding: 12px;
@@ -611,6 +611,21 @@
       color: #484f58;
     }
 
+    /* ── Cron Jobs ── */
+    .cron-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 0;
+      border-bottom: 1px solid var(--border);
+      font-size: 12px;
+    }
+    .cron-row:last-child { border-bottom: none; }
+    .cron-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
+    .cron-name { font-weight: 500; color: var(--text); flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .cron-agent { font-size: 11px; color: var(--muted); }
+    .cron-meta { font-size: 11px; color: var(--muted); font-family: "JetBrains Mono", Consolas, monospace; margin-left: auto; flex-shrink: 0; }
+
     /* ── System Metrics ── */
     .metric-row { margin-bottom: 12px; }
     .metric-row:last-child { margin-bottom: 0; }
@@ -740,7 +755,7 @@
       .app { height: auto; }
       .dashboard-grid {
         grid-template-columns: 1fr;
-        grid-template-rows: repeat(4, 360px);
+        grid-template-rows: repeat(4, 360px) auto;
         height: auto;
       }
       .board { min-width: unset; flex-direction: column; }
@@ -798,6 +813,16 @@
           <span class="panel-count mono" id="mac-label">live</span>
         </div>
         <div class="panel-body" id="mac-root">
+          <div class="empty-panel">Loading…</div>
+        </div>
+      </section>
+
+      <section class="panel" id="crons" style="grid-column: 1 / -1; min-height: 120px;">
+        <div class="panel-header">
+          <span>Cron Jobs</span>
+          <span class="panel-count" id="crons-count">—</span>
+        </div>
+        <div class="panel-body" id="crons-root" style="overflow-y: auto; max-height: 200px;">
           <div class="empty-panel">Loading…</div>
         </div>
       </section>
@@ -1235,10 +1260,43 @@
       }
     }
 
+    async function loadCrons() {
+      try {
+        const res = await fetch("/api/crons");
+        if (!res.ok) throw new Error("HTTP " + res.status);
+        const jobs = await res.json();
+        const countEl = document.getElementById("crons-count");
+        const rootEl = document.getElementById("crons-root");
+        if (countEl) countEl.textContent = jobs.length;
+        if (!jobs.length) {
+          if (rootEl) rootEl.innerHTML = `<div class="empty-state"><div class="empty-state-icon">⏱</div><div>No cron jobs</div><div class="empty-state-detail">Set OPENCLAW_GATEWAY_CRONS_JSON env var</div></div>`;
+          return;
+        }
+        if (rootEl) rootEl.innerHTML = jobs.map(j => {
+          const dotColor = j.consecutive_errors > 0 ? "#f85149" : j.last_status === "ok" ? "#3fb950" : "#e3b341";
+          const interval = j.interval_min ? j.interval_min + "m" : "?";
+          const lastRun = j.last_run ? relTime(j.last_run) : "never";
+          const dur = j.last_duration_ms ? Math.round(j.last_duration_ms / 1000) + "s" : "";
+          return `<div class="cron-row">
+            <span class="cron-dot" style="background:${dotColor}"></span>
+            <div style="flex:1;min-width:0">
+              <div class="cron-name">${escHtml(j.name)}</div>
+              <div class="cron-agent">${escHtml(j.agent)} · every ${escHtml(interval)}</div>
+            </div>
+            <div class="cron-meta">${escHtml(lastRun)}${dur ? " · " + escHtml(dur) : ""}</div>
+          </div>`;
+        }).join("");
+      } catch(e) {
+        const rootEl = document.getElementById("crons-root");
+        if (rootEl) rootEl.innerHTML = `<div class="empty-state">Cron data unavailable</div>`;
+      }
+    }
+
     function loadAll() {
       loadKanban();
       loadAgents();
       loadSystem();
+      loadCrons();
     }
 
     // Initial load
@@ -1249,6 +1307,7 @@
     // Refresh all panels every 30s
     agentsRefreshTimer = setInterval(loadAgents, 30000);
     setInterval(loadSystem, 30000);
+    setInterval(loadCrons, 60000);
   </script>
 </body>
 </html>


### PR DESCRIPTION
Closes #59

Adds a full-width Cron Jobs panel at the bottom of the dashboard. Backend reads from OPENCLAW_GATEWAY_CRONS_JSON env var. Shows: name, agent, interval, last run time, duration, status dot (green/red). Graceful empty state when env var not set.