### PR TITLE
feat: network I/O + hostname label fix (#71)

### DIFF
--- a/app/system.py
+++ b/app/system.py
@@ -20,6 +20,7 @@ import psutil
 
 MAC_SSH_HOST = os.getenv("MAC_SSH_HOST", "")  # e.g. "user@192.168.x.x"
 MAC_SSH_PORT = int(os.getenv("MAC_SSH_PORT", "22"))
+SERVER_LABEL = os.getenv("SERVER_LABEL", "")
 
 _metrics_cache: dict = {}
 _metrics_cache_time: float = 0.0
@@ -50,6 +51,7 @@ def _get_server_metrics_fresh() -> dict[str, Any]:
     cpu = psutil.cpu_percent(interval=0.5)
     mem = psutil.virtual_memory()
     disk = psutil.disk_usage("/")
+    net = psutil.net_io_counters()
 
     temps: dict[str, float] = {}
     try:
@@ -82,7 +84,11 @@ def _get_server_metrics_fresh() -> dict[str, Any]:
         "container_count": len(containers),
         "docker_available": docker_available,
         "label": "Hetzner Server",
-        "hostname": _get_hostname(),
+        "hostname": SERVER_LABEL or _get_hostname(),
+        "network": {
+            "bytes_sent": net.bytes_sent,
+            "bytes_recv": net.bytes_recv,
+        },
     }
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - KANBAN_REPOS=ddfeyes/ops-dashboard,ddfeyes/svc-dash
       - GH_TOKEN=${GH_TOKEN}
       - SESSION_TOKEN_LIMIT=200000
+      - SERVER_LABEL=Hetzner
       - WEEKLY_ALL_TOKEN_LIMIT=10000000
       - WEEKLY_SONNET_TOKEN_LIMIT=7500000
     volumes:

--- a/static/index.html
+++ b/static/index.html
@@ -1173,6 +1173,16 @@
         document.getElementById(labelId).textContent = server.hostname || "live";
       }
 
+      const net = server.network || {};
+      let netHtml = "";
+      if (net.bytes_sent != null) {
+        const fmtBytes = b => b > 1073741824 ? (b/1073741824).toFixed(1)+"GB" : b > 1048576 ? (b/1048576).toFixed(0)+"MB" : (b/1024).toFixed(0)+"KB";
+        netHtml = `<div class="metric-row" style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px">
+    <span style="font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.6px">NET ↑↓</span>
+    <span style="font-size:12px;font-weight:500;font-family:'JetBrains Mono',monospace;color:var(--muted)">${fmtBytes(net.bytes_sent)} / ${fmtBytes(net.bytes_recv)}</span>
+  </div>`;
+      }
+
       const temps = server.temperatures || {};
       const tempC = temps.Tctl || temps.Composite || null;
       let tempHtml = "";
@@ -1188,6 +1198,7 @@
         metricBarHtml("CPU", server.cpu_percent || 0, "") +
         metricBarHtml("Memory", mem.percent || 0, memDetail) +
         metricBarHtml("Disk", disk.percent || 0, diskDetail) +
+        netHtml +
         tempHtml;
     }
 


### PR DESCRIPTION
Closes #71

Adds NET ↑↓ row to Hetzner Server panel showing total bytes sent/recv (formatted as KB/MB/GB). Also fixes the panel badge label to show 'Hetzner' instead of Docker container ID via SERVER_LABEL env var.