### PR TITLE
feat: load average in Hetzner Server panel (#75)

### DIFF
--- a/app/system.py
+++ b/app/system.py
@@ -53,6 +53,8 @@ def _get_server_metrics_fresh() -> dict[str, Any]:
     disk = psutil.disk_usage("/")
     net = psutil.net_io_counters()
     boot_time = psutil.boot_time()
+    load1, load5, load15 = psutil.getloadavg()
+    cpu_count = psutil.cpu_count() or 1
 
     temps: dict[str, float] = {}
     try:
@@ -91,6 +93,12 @@ def _get_server_metrics_fresh() -> dict[str, Any]:
             "bytes_recv": net.bytes_recv,
         },
         "uptime_seconds": int(time.time() - boot_time),
+        "load_avg": {
+            "load1": round(load1, 2),
+            "load5": round(load5, 2),
+            "load15": round(load15, 2),
+            "cpu_count": cpu_count,
+        },
     }
 
 

--- a/static/index.html
+++ b/static/index.html
@@ -1192,6 +1192,17 @@
   </div>`;
       }
 
+      let loadHtml = "";
+      const load = server.load_avg || {};
+      if (load.load1 != null) {
+        const cpus = load.cpu_count || 1;
+        const loadColor = load.load1 >= cpus ? "#f85149" : load.load1 >= cpus*0.7 ? "#e3b341" : "#3fb950";
+        loadHtml = `<div class="metric-row" style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px">
+    <span style="font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.6px">LOAD</span>
+    <span style="font-size:12px;font-weight:500;font-family:'JetBrains Mono',monospace;color:${loadColor}">${load.load1} / ${load.load5} / ${load.load15}</span>
+  </div>`;
+      }
+
       const temps = server.temperatures || {};
       const tempC = temps.Tctl || temps.Composite || null;
       let tempHtml = "";
@@ -1209,6 +1220,7 @@
         metricBarHtml("Disk", disk.percent || 0, diskDetail) +
         netHtml +
         uptimeHtml +
+        loadHtml +
         tempHtml;
     }
 


### PR DESCRIPTION
Closes #75

Adds LOAD row showing 1m/5m/15m load averages. Color-coded by load relative to CPU count: green <70%, amber <100%, red >=100%.