### PR TITLE
fix: 2x2 compact grid in server panel — TEMP now visible (#77)

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1173,55 +1173,47 @@
         document.getElementById(labelId).textContent = server.hostname || "live";
       }
 
-      const net = server.network || {};
-      let netHtml = "";
-      if (net.bytes_sent != null) {
-        const fmtBytes = b => b > 1073741824 ? (b/1073741824).toFixed(1)+"GB" : b > 1048576 ? (b/1048576).toFixed(0)+"MB" : (b/1024).toFixed(0)+"KB";
-        netHtml = `<div class="metric-row" style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px">
-    <span style="font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.6px">NET ↑↓</span>
-    <span style="font-size:12px;font-weight:500;font-family:'JetBrains Mono',monospace;color:var(--muted)">${fmtBytes(net.bytes_sent)} / ${fmtBytes(net.bytes_recv)}</span>
-  </div>`;
+      // Build compact 2×2 grid of secondary metrics
+      const _compactItems = [];
+
+      const _net = server.network || {};
+      if (_net.bytes_sent != null) {
+        const _fb = b => b > 1073741824 ? (b/1073741824).toFixed(1)+"GB" : b > 1048576 ? (b/1048576).toFixed(0)+"MB" : (b/1024).toFixed(0)+"KB";
+        _compactItems.push(["NET ↑↓", _fb(_net.bytes_sent)+" / "+_fb(_net.bytes_recv), "var(--muted)"]);
       }
 
-      let uptimeHtml = "";
       if (server.uptime_seconds != null) {
-        const fmtUptime = s => s < 3600 ? Math.floor(s/60)+"m" : s < 86400 ? Math.floor(s/3600)+"h "+Math.floor((s%3600)/60)+"m" : Math.floor(s/86400)+"d "+Math.floor((s%86400)/3600)+"h";
-        uptimeHtml = `<div class="metric-row" style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px">
-    <span style="font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.6px">UPTIME</span>
-    <span style="font-size:12px;font-weight:500;font-family:'JetBrains Mono',monospace;color:var(--muted)">${fmtUptime(server.uptime_seconds)}</span>
-  </div>`;
+        const _u = server.uptime_seconds;
+        const _fmt = _u < 3600 ? Math.floor(_u/60)+"m" : _u < 86400 ? Math.floor(_u/3600)+"h "+Math.floor((_u%3600)/60)+"m" : Math.floor(_u/86400)+"d "+Math.floor((_u%86400)/3600)+"h";
+        _compactItems.push(["UPTIME", _fmt, "var(--muted)"]);
       }
 
-      let loadHtml = "";
-      const load = server.load_avg || {};
-      if (load.load1 != null) {
-        const cpus = load.cpu_count || 1;
-        const loadColor = load.load1 >= cpus ? "#f85149" : load.load1 >= cpus*0.7 ? "#e3b341" : "#3fb950";
-        loadHtml = `<div class="metric-row" style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px">
-    <span style="font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.6px">LOAD</span>
-    <span style="font-size:12px;font-weight:500;font-family:'JetBrains Mono',monospace;color:${loadColor}">${load.load1} / ${load.load5} / ${load.load15}</span>
-  </div>`;
+      const _load = server.load_avg || {};
+      if (_load.load1 != null) {
+        const _cpus = _load.cpu_count || 1;
+        const _lc = _load.load1 >= _cpus ? "#f85149" : _load.load1 >= _cpus*0.7 ? "#e3b341" : "#3fb950";
+        _compactItems.push(["LOAD", _load.load1+" / "+_load.load5+" / "+_load.load15, _lc]);
       }
 
-      const temps = server.temperatures || {};
-      const tempC = temps.Tctl || temps.Composite || null;
-      let tempHtml = "";
-      if (tempC != null) {
-        const tempColor = tempC > 85 ? "#f85149" : tempC > 70 ? "#e3b341" : "#3fb950";
-        tempHtml = `<div class="metric-row" style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px">
-    <span style="font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.6px">Temp</span>
-    <span style="font-size:13px;font-weight:600;font-family:'JetBrains Mono',monospace;color:${tempColor}">${tempC.toFixed(1)}°C</span>
-  </div>`;
+      const _temps = server.temperatures || {};
+      const _tempC = _temps.Tctl || _temps.Composite || null;
+      if (_tempC != null) {
+        const _tc = _tempC > 85 ? "#f85149" : _tempC > 70 ? "#e3b341" : "#3fb950";
+        _compactItems.push(["TEMP", _tempC.toFixed(1)+"°C", _tc]);
       }
+
+      const _grid = _compactItems.length ? `<div style="display:grid;grid-template-columns:1fr 1fr;gap:0 16px;margin-top:6px">${
+        _compactItems.map(([lbl, val, col]) => `<div style="display:flex;justify-content:space-between;align-items:center;padding:3px 0;border-bottom:1px solid var(--border)">
+    <span style="font-size:10px;color:var(--muted);text-transform:uppercase;letter-spacing:.5px">${lbl}</span>
+    <span style="font-size:11px;font-weight:600;font-family:'JetBrains Mono',monospace;color:${col}">${val}</span>
+  </div>`).join("")
+      }</div>` : "";
 
       document.getElementById(rootId).innerHTML =
         metricBarHtml("CPU", server.cpu_percent || 0, "") +
         metricBarHtml("Memory", mem.percent || 0, memDetail) +
         metricBarHtml("Disk", disk.percent || 0, diskDetail) +
-        netHtml +
-        uptimeHtml +
-        loadHtml +
-        tempHtml;
+        _grid;
     }
 
     function renderContainersPanel(server) {


### PR DESCRIPTION
Closes #77

Reorganizes NET/UPTIME/LOAD/TEMP from 4 stacked rows into a 2×2 grid, halving their vertical space. All 7 metrics now visible without overflow.