### PR TITLE
feat: hide empty Kanban columns (#81)

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -947,7 +947,7 @@
         byCol[col].push(card);
       });
 
-      const html = COLUMNS.map(col => {
+      const html = COLUMNS.filter(col => col.key === "backlog" || byCol[col.key].length > 0).map(col => {
         const colCards = byCol[col.key];
         const cardsHtml = colCards.length
           ? colCards.map(cardHtml).join("")


### PR DESCRIPTION
Closes #81

Filters COLUMNS before rendering so empty columns (0 cards) are not shown. Backlog is always visible. With IN PROGRESS=0 and BLOCKED=0, the board now shows only BACKLOG, DONE instead of all 5 columns, giving more space to visible content.