### PR TITLE
feat: Local Machine metrics panel (#83)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -17,7 +17,7 @@ from fastapi.staticfiles import StaticFiles
 from app.agents import get_ao_sessions, get_openclaw_agents
 from app.crons import get_crons
 from app.kanban import fetch_kanban_cards
-from app.system import get_hetzner_metrics, get_mac_metrics, get_server_metrics
+from app.system import get_hetzner_metrics, get_local_machine_metrics, get_mac_metrics, get_server_metrics
 from app.usage import get_usage
 
 _START_TIME = _time_module.time()
@@ -148,13 +148,16 @@ async def system_metrics() -> dict[str, Any]:
     else:
         mac = mac_result
 
-    # Legacy keys for backward compat with old frontend
+    # Local machine metrics (pre-computed by push-env.sh on the host)
+    local = get_local_machine_metrics()
+
     return {
         "server": server,
         "server_error": server_error,
-        "mac": server,  # frontend "mac" panel now shows server metrics
-        "hetzner": server,  # keep legacy key
+        "hetzner": server,
         "hetzner_error": server_error,
+        "local": local,
+        "mac": server,  # legacy key
         "mac_remote": mac,
         "mac_remote_error": mac_error,
     }

--- a/app/system.py
+++ b/app/system.py
@@ -211,6 +211,21 @@ def get_mac_metrics() -> dict[str, Any] | None:
 
 
 # ---------------------------------------------------------------------------
+# Local machine metrics — pre-computed by push-env.sh, injected via env var
+# ---------------------------------------------------------------------------
+
+def get_local_machine_metrics() -> dict[str, Any] | None:
+    """Return local machine metrics pushed via LOCAL_MACHINE_JSON env var."""
+    raw = os.getenv("LOCAL_MACHINE_JSON", "")
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
 # Backward-compat shims used by main.py
 # ---------------------------------------------------------------------------
 

--- a/scripts/push-env.sh
+++ b/scripts/push-env.sh
@@ -8,6 +8,73 @@ HETZNER_PASS="VibeUser32345001f"
 REMOTE_DIR="/home/user3/ops-dashboard"
 ENV_FILE="/tmp/ops-dashboard-push.env"
 
+echo "==> Computing local machine metrics..."
+LOCAL_MACHINE_JSON=$(python3 - << 'PYEOF'
+import json, time, os
+
+with open('/proc/stat') as f:
+    cpu_line = f.readline()
+vals = list(map(int, cpu_line.split()[1:]))
+idle, total = vals[3], sum(vals)
+time.sleep(0.3)
+with open('/proc/stat') as f:
+    cpu_line2 = f.readline()
+vals2 = list(map(int, cpu_line2.split()[1:]))
+idle2, total2 = vals2[3], sum(vals2)
+cpu_pct = round(100 * (1 - (idle2-idle)/(total2-total)), 1)
+
+mem = {}
+with open('/proc/meminfo') as f:
+    for line in f:
+        k, v = line.split(':')
+        mem[k.strip()] = int(v.split()[0])
+mem_total = round(mem['MemTotal']/1024**2, 2)
+mem_avail = round(mem['MemAvailable']/1024**2, 2)
+mem_used = round((mem['MemTotal']-mem['MemAvailable'])/1024**2, 2)
+mem_pct = round(100*mem_used/mem_total, 1)
+
+import shutil
+disk = shutil.disk_usage('/')
+disk_total = round(disk.total/1024**3, 2)
+disk_used = round(disk.used/1024**3, 2)
+disk_pct = round(100*disk_used/disk_total, 1)
+
+with open('/proc/loadavg') as f:
+    la = f.read().split()
+load1, load5, load15 = float(la[0]), float(la[1]), float(la[2])
+cpu_count = os.cpu_count() or 1
+
+with open('/proc/uptime') as f:
+    uptime_sec = int(float(f.read().split()[0]))
+
+net_sent, net_recv = 0, 0
+with open('/proc/net/dev') as f:
+    for line in f:
+        parts = line.split()
+        if len(parts) < 10 or ':' not in parts[0]:
+            continue
+        iface = parts[0].rstrip(':')
+        if iface == 'lo':
+            continue
+        net_recv += int(parts[1])
+        net_sent += int(parts[9])
+
+hostname = open('/etc/hostname').read().strip() if os.path.exists('/etc/hostname') else 'local'
+
+result = {
+    'cpu_percent': cpu_pct, 'cpu_count': cpu_count,
+    'memory': {'total_gb': mem_total, 'used_gb': mem_used, 'percent': mem_pct},
+    'disk': {'total_gb': disk_total, 'used_gb': disk_used, 'percent': disk_pct},
+    'network': {'bytes_sent': net_sent, 'bytes_recv': net_recv},
+    'load_avg': {'load1': load1, 'load5': load5, 'load15': load15, 'cpu_count': cpu_count},
+    'uptime_seconds': uptime_sec,
+    'hostname': hostname,
+    'label': 'Local Machine'
+}
+print(json.dumps(result, separators=(',', ':')))
+PYEOF
+)
+
 echo "==> Computing agent status..."
 AGENTS_STATUS=$(python3 - << 'PYEOF'
 import json, os
@@ -51,6 +118,7 @@ OPENCLAW_AGENTS_STATUS_JSON=${AGENTS_STATUS}
 GH_TOKEN=${GH_TOKEN}
 EOF
 printf 'OPENCLAW_GATEWAY_CRONS_JSON=%s\n' "$CRONS_JSON" >> "$ENV_FILE"
+printf 'LOCAL_MACHINE_JSON=%s\n' "$LOCAL_MACHINE_JSON" >> "$ENV_FILE"
 
 echo "==> Pushing to Hetzner..."
 sshpass -p "$HETZNER_PASS" scp -P "$HETZNER_PORT" -o StrictHostKeyChecking=no \

--- a/static/index.html
+++ b/static/index.html
@@ -87,7 +87,7 @@
     .dashboard-grid {
       display: grid;
       grid-template-columns: 1fr 1fr;
-      grid-template-rows: 2fr 1fr auto;
+      grid-template-rows: 2fr 1fr 1fr auto;
       gap: 12px;
       height: calc(100vh - 48px);
       padding: 12px;
@@ -755,7 +755,7 @@
       .app { height: auto; }
       .dashboard-grid {
         grid-template-columns: 1fr;
-        grid-template-rows: 500px 500px 360px 360px auto;
+        grid-template-rows: 500px 500px 360px 360px 360px auto;
         height: auto;
       }
       .board { min-width: unset; flex-direction: column; }
@@ -813,6 +813,16 @@
           <span class="panel-count mono" id="mac-label">live</span>
         </div>
         <div class="panel-body" id="mac-root">
+          <div class="empty-panel">Loading…</div>
+        </div>
+      </section>
+
+      <section class="panel" id="system-local">
+        <div class="panel-header">
+          <span>Local Machine</span>
+          <span class="panel-count mono" id="local-label">—</span>
+        </div>
+        <div class="panel-body" id="local-root">
           <div class="empty-panel">Loading…</div>
         </div>
       </section>
@@ -1278,7 +1288,6 @@
         const res = await fetch("/api/system");
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json();
-        // server = local psutil (Hetzner), mac = mac metrics
         const server = data.server || data.hetzner || data.mac;
         const serverErr = data.server_error || data.hetzner_error;
         if (serverErr) {
@@ -1287,6 +1296,19 @@
           document.getElementById("mac-label").textContent = "error";
         } else {
           renderServerMetrics(server, "mac-root", "mac-label");
+        }
+        // Local machine metrics (pushed via push-env.sh from hui20metrov-MP200)
+        const local = data.local;
+        const localRootEl = document.getElementById("local-root");
+        const localLabelEl = document.getElementById("local-label");
+        if (local && !local.error) {
+          renderServerMetrics(local, "local-root", "local-label");
+        } else if (local && local.error) {
+          if (localRootEl) localRootEl.innerHTML = `<div class="status-error"><div class="status-error-icon">!</div><div><div>Error</div><div class="status-error-detail">${escHtml(local.error)}</div></div></div>`;
+          if (localLabelEl) localLabelEl.textContent = "error";
+        } else {
+          if (localRootEl) localRootEl.innerHTML = `<div class="empty-state"><div class="empty-state-icon">💻</div><div>No data</div><div class="empty-state-detail">Run push-env.sh to inject LOCAL_MACHINE_JSON</div></div>`;
+          if (localLabelEl) localLabelEl.textContent = "offline";
         }
         renderContainersPanel(server);
       } catch (err) {


### PR DESCRIPTION
## What
Добавляет панель Local Machine с реальными метриками хост-машины hui20metrov-MP200.

## How
- `push-env.sh` теперь читает метрики из `/proc` (без psutil) и пушит как `LOCAL_MACHINE_JSON`
- `get_local_machine_metrics()` в system.py десериализует env var
- `/api/system` возвращает новый ключ `local`
- Фронт рендерит панель Local Machine через тот же `renderServerMetrics()`
- Grid обновлён: 4 ряда (2fr 1fr 1fr auto)

## Self-test
- `LOCAL_MACHINE_JSON` присутствует в контейнере (проверено docker exec)
- push-env.sh отрабатывает успешно
- Ждёт деплоя нового кода через NAVI