### PR TITLE
fix: row 2 height 1.5fr — all server metrics visible (#84)

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -87,7 +87,7 @@
     .dashboard-grid {
       display: grid;
       grid-template-columns: 1fr 1fr;
-      grid-template-rows: 2fr 1fr 1fr auto;
+      grid-template-rows: 2fr 1.5fr 1fr auto;
       gap: 12px;
       height: calc(100vh - 48px);
       padding: 12px;


### PR DESCRIPTION
Closes #84

Changes grid-template-rows from 2fr 1fr 1fr auto to 2fr 1.5fr 1fr auto. Row 2 (Server panels) gets 50% more height, enough to display all 7 metrics including LOAD and TEMP in the 2x2 compact grid.