### PR TITLE
fix(#88): local panel freshness indicator — computed_at + staleness badge

### DIFF
--- a/scripts/push-env.sh
+++ b/scripts/push-env.sh
@@ -11,6 +11,7 @@ ENV_FILE="/tmp/ops-dashboard-push.env"
 echo "==> Computing local machine metrics..."
 LOCAL_MACHINE_JSON=$(python3 - << 'PYEOF'
 import json, time, os
+from datetime import datetime, timezone
 
 with open('/proc/stat') as f:
     cpu_line = f.readline()
@@ -69,7 +70,8 @@ result = {
     'load_avg': {'load1': load1, 'load5': load5, 'load15': load15, 'cpu_count': cpu_count},
     'uptime_seconds': uptime_sec,
     'hostname': hostname,
-    'label': 'Local Machine'
+    'label': 'Local Machine',
+    'computed_at': datetime.now(timezone.utc).isoformat()
 }
 print(json.dumps(result, separators=(',', ':')))
 PYEOF

--- a/static/index.html
+++ b/static/index.html
@@ -1184,6 +1184,24 @@
         document.getElementById(labelId).textContent = server.hostname || "live";
       }
 
+      // Freshness badge — only for local-root (push-env data can be stale)
+      if (rootId === "local-root" && labelId) {
+        const ageMs = server.computed_at ? Date.now() - new Date(server.computed_at).getTime() : 0;
+        const existingBadge = document.getElementById("local-freshness-badge");
+        if (existingBadge) existingBadge.remove();
+        if (ageMs > 0) {
+          const ageColor = ageMs > 1800000 ? "#f85149" : ageMs > 300000 ? "#e3b341" : "#8b949e";
+          const badge = document.createElement("div");
+          badge.id = "local-freshness-badge";
+          badge.style.cssText = "font-size:10px;color:" + ageColor + ";margin-top:2px;";
+          badge.textContent = "⏱ " + Math.round(ageMs / 60000) + "m ago";
+          const labelEl = document.getElementById(labelId);
+          if (labelEl && labelEl.parentNode) {
+            labelEl.parentNode.insertBefore(badge, labelEl.nextSibling);
+          }
+        }
+      }
+
       // Build compact 2×2 grid of secondary metrics
       const _compactItems = [];
 


### PR DESCRIPTION
## Problem
Local Machine panel shows data from push-env.sh which runs on a schedule. There was no way to tell how stale the data was.

## Solution
1. **`scripts/push-env.sh`**: Added `computed_at` (UTC ISO timestamp) to the `LOCAL_MACHINE_JSON` result dict. Also imports `timezone` from `datetime`.

2. **`static/index.html`**: `renderServerMetrics` now renders a small freshness badge below the local-label element when `rootId === "local-root"`:
   - 🟢 `#8b949e` (muted) — < 5 minutes old
   - 🟡 `#e3b341` (amber) — 5–30 minutes old  
   - 🔴 `#f85149` (red) — > 30 minutes old
   - Badge shows `⏱ Xm ago`
   - Badge is **not shown** for mac-root or hetzner panels (live data)
   - Badge is skipped entirely if `computed_at` is absent

Closes #88