### PR TITLE
fix(#103): move Hetzner creds to gitignored .hetzner-creds file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 .env
 venv/
 ops-dashboard.env
+.hetzner-creds

--- a/.hetzner-creds.example
+++ b/.hetzner-creds.example
@@ -1,0 +1,4 @@
+# Copy to .hetzner-creds and fill in real values (this file is gitignored)
+HETZNER_HOST="user3@YOUR_SERVER_IP"
+HETZNER_PORT="2203"
+HETZNER_PASS="your_password_here"

--- a/scripts/push-env.sh
+++ b/scripts/push-env.sh
@@ -2,9 +2,21 @@
 # push-env.sh — Compute and push ops-dashboard.env to Hetzner
 set -euo pipefail
 
-HETZNER_HOST="user3@94.130.65.86"
-HETZNER_PORT="2203"
-HETZNER_PASS="VibeUser32345001f"
+# Load Hetzner credentials from env or local creds file
+_CREDS_FILE="$(dirname "$0")/../.hetzner-creds"
+if [ -f "$_CREDS_FILE" ]; then
+  # shellcheck source=/dev/null
+  source "$_CREDS_FILE"
+fi
+
+HETZNER_HOST="${HETZNER_HOST:-user3@94.130.65.86}"
+HETZNER_PORT="${HETZNER_PORT:-2203}"
+HETZNER_PASS="${HETZNER_PASS:-}"
+
+if [ -z "$HETZNER_PASS" ]; then
+  echo "ERROR: HETZNER_PASS not set. Create .hetzner-creds or export HETZNER_PASS." >&2
+  exit 1
+fi
 REMOTE_DIR="/home/user3/ops-dashboard"
 ENV_FILE="/tmp/ops-dashboard-push.env"
 


### PR DESCRIPTION
Removes hardcoded HETZNER_PASS/HOST/PORT from push-env.sh. Credentials now loaded from .hetzner-creds (gitignored) or environment variables. Adds .hetzner-creds.example as reference. Closes #103