### PR TITLE
design: panel header visual hierarchy — kanban dominant, secondary panels compact

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -138,7 +138,7 @@
     }
 
     .panel-header {
-      height: 36px;
+      height: 34px;
       flex-shrink: 0;
       padding: 0 12px;
       display: flex;
@@ -151,6 +151,14 @@
       letter-spacing: 0.10em;
       color: var(--muted);
       border-bottom: 1px solid var(--border);
+    }
+
+    /* Kanban header — primary panel gets dominant treatment */
+    #kanban .panel-header {
+      height: 38px;
+      font-size: 11px;
+      background: #1a2030;
+      border-bottom-color: rgba(88,166,255,0.2);
     }
 
     .panel-body {
@@ -443,11 +451,13 @@
     .filter-btn:hover:not(.active) { border-color: var(--muted); color: var(--text); }
 
     /* ── Agent Monitor ── */
-    .panel-count {
-      background: rgba(255,255,255,0.08);
-      padding: 1px 7px;
-      border-radius: 10px;
-      font-size: 11px;
+    .panel-header .panel-count {
+      font-size: 10px;
+      font-family: 'JetBrains Mono', monospace;
+      background: rgba(88,166,255,0.10);
+      color: var(--accent);
+      padding: 1px 6px;
+      border-radius: 4px;
       font-weight: 500;
     }
 


### PR DESCRIPTION
## Summary

Fixes #114

Implements the panel header visual hierarchy improvements from issue #114:

- **Tighter secondary headers**: `.panel-header` height reduced from 36px → 34px, recovering vertical space for content
- **Dominant kanban header**: `#kanban .panel-header` gets height 38px, font-size 11px, a slightly warmer background (`#1a2030`), and an accent-blue bottom border (`rgba(88,166,255,0.2)`) to signal its primary status
- **Accent panel-count badges**: `.panel-header .panel-count` updated to use accent color + JetBrains Mono + subtle blue tint background — reinforces active-data context at a glance

## Visual impact
- Kanban now reads as dominant at first glance
- Secondary panels (agents, metrics, crons) visually defer without any structural change
- Reduced cognitive load when scanning the dashboard