### PR TITLE
fix: agent-dot status colors — active=green idle=amber offline=gray (#115)

### DIFF
--- a/app/kanban.py
+++ b/app/kanban.py
@@ -6,6 +6,8 @@ import re
 import subprocess
 from typing import Optional
 
+from app.agents import get_openclaw_agents
+
 # Repos to fetch — override with KANBAN_REPOS env var (comma-separated)
 DEFAULT_REPOS = ["ddfeyes/ops-dashboard", "ddfeyes/svc-dash"]
 
@@ -84,9 +86,13 @@ def _build_card(
     pr_url: Optional[str],
     timestamp: Optional[str],
     url: str,
+    agent_statuses: dict[str, str] | None = None,
 ) -> dict:
     tags = list({_label_to_tag(n) for n in label_names})
     agent = assignees[0]["login"] if assignees else None
+    agent_status: Optional[str] = None
+    if agent and agent_statuses:
+        agent_status = agent_statuses.get(agent.lower())
     return {
         "id": card_id,
         "title": title,
@@ -94,9 +100,23 @@ def _build_card(
         "tags": tags,
         "pr_url": pr_url,
         "agent": agent,
+        "agent_status": agent_status,
         "timestamp": timestamp,
         "url": url,
     }
+
+
+def _build_agent_statuses() -> dict[str, str]:
+    """Build a login→status mapping from the agents list (best-effort)."""
+    try:
+        agents = get_openclaw_agents()
+        return {
+            (a.get("id") or "").lower(): a.get("status") or "offline"
+            for a in agents
+            if a.get("id")
+        }
+    except Exception:
+        return {}
 
 
 def fetch_kanban_cards() -> list[dict]:
@@ -107,6 +127,7 @@ def fetch_kanban_cards() -> list[dict]:
     board rather than crashing).
     """
     repos = _get_repos()
+    agent_statuses = _build_agent_statuses()
     cards: list[dict] = []
 
     for repo in repos:
@@ -166,6 +187,7 @@ def fetch_kanban_cards() -> list[dict]:
                 pr_url=linked_pr["url"] if linked_pr else None,
                 timestamp=timestamp,
                 url=issue["url"],
+                agent_statuses=agent_statuses,
             ))
 
         # Standalone open PRs (not linked to any issue in this repo)
@@ -184,6 +206,7 @@ def fetch_kanban_cards() -> list[dict]:
                 pr_url=pr["url"],
                 timestamp=pr.get("createdAt"),
                 url=pr["url"],
+                agent_statuses=agent_statuses,
             ))
 
     return cards

--- a/static/index.html
+++ b/static/index.html
@@ -368,7 +368,7 @@
     .agent-dot {
       width: 6px; height: 6px;
       border-radius: 50%;
-      background: var(--accent);
+      background: var(--muted);
       flex-shrink: 0;
     }
     .card-time { font-size: 11px; color: var(--muted); }
@@ -1070,8 +1070,11 @@
            </a>`
         : "";
 
+      const agentColor = card.agent_status === 'active' ? '#3fb950'
+        : card.agent_status === 'idle' ? '#e3b341'
+        : '#8b949e';
       const agent = card.agent
-        ? `<span class="card-agent"><span class="agent-dot"></span>${escHtml(card.agent)}</span>`
+        ? `<span class="card-agent"><span class="agent-dot" style="background:${agentColor}"></span>${escHtml(card.agent)}</span>`
         : "";
 
       const ts = card.timestamp ? `<span class="card-time">${relTime(card.timestamp)}</span>` : "";


### PR DESCRIPTION
## Summary

Fixes #115

The `.agent-dot` on kanban cards previously had a hardcoded `background: var(--accent)` (always blue), providing no status signal.

## Changes

### `static/index.html` — CSS
- Changed `.agent-dot` background from `var(--accent)` to `var(--muted)` as a neutral default (JS overrides inline per-card)

### `static/index.html` — JS (`cardHtml()`)
- Added `agentColor` derived from `card.agent_status`:
  - `active` → `#3fb950` (green)
  - `idle` → `#e3b341` (amber)
  - otherwise → `#8b949e` (gray/offline)
- Passes color as inline style on the `agent-dot` span

### `app/kanban.py` — Backend
- Added `_build_agent_statuses()` helper that calls `get_openclaw_agents()` and builds a `login→status` dict
- Updated `_build_card()` to accept `agent_statuses` and inject `agent_status` into each card dict
- Both `_build_card()` call sites now pass `agent_statuses=agent_statuses`