### PR TITLE
test(#145): add smoke tests for /api/usage and /api/crons

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -37,3 +37,20 @@ def test_system_returns_expected_keys():
     data = r.json()
     assert "mac" in data
     assert "hetzner" in data
+
+
+def test_usage_returns_expected_keys():
+    """Usage endpoint must return session/weekly token stats and source."""
+    r = client.get("/api/usage")
+    assert r.status_code == 200
+    data = r.json()
+    assert "current_session" in data
+    assert "weekly_all" in data
+    assert "source" in data
+
+
+def test_crons_returns_list():
+    """Crons endpoint must return a JSON list (may be empty in test env)."""
+    r = client.get("/api/crons")
+    assert r.status_code == 200
+    assert isinstance(r.json(), list)


### PR DESCRIPTION
Expands test coverage from 4 → 6 smoke tests.

## Added
- `test_usage_returns_expected_keys` — asserts `/api/usage` returns `current_session`, `weekly_all`, `source`
- `test_crons_returns_list` — asserts `/api/crons` returns a JSON list

## Result
`pytest tests/ -v` → **6 passed**, 0 warnings

Closes #145