### PR TITLE
fix(usage): prevent orphaned 0%-width bar track in empty state

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1919,12 +1919,17 @@
       const resetIso  = (data.reset_times || {}).weekly || "";
       const byModel   = weekly.by_model || {};
 
-      // All-zeros detection
-      const allZero = !sess.total_tokens && !weekly.total_tokens;
+      // All-zeros / no-data detection — also guard against 0% bars (gray track showing through)
+      const hasSession = sess.total_tokens > 0 || (sessPct > 0.1);
+      const hasWeekly  = weekly.total_tokens > 0 || (wkAllPct > 0.1);
+      const allZero   = !hasSession && !hasWeekly;
 
       if (allZero) {
+        // Wipe first so any residual .metric-bar-wrap backgrounds can't bleed through
+        rootEl.textContent = "";
+        rootEl.style.cssText = "display:flex;align-items:center;justify-content:center;min-height:140px;";
         rootEl.innerHTML = `
-          <div class="empty-state">
+          <div class="empty-state" style="position:relative;">
             <div class="empty-state-icon">📊</div>
             <div>No usage data available</div>
             <div class="empty-state-detail">


### PR DESCRIPTION
Fixes #153 — orphaned bar chart fragment in API USAGE empty state.

**Root cause:** The all-zeros detection only checked raw token counts. When session or weekly had 0% bar (e.g. 0 tokens / 200000 limit), the gray .metric-bar-wrap background was still rendered, visible through the empty bar fill — looking like an orphaned bar chart fragment.

**Fix:**
- Guard against 0%-pct bars by checking (sessPct > 0.1) in addition to raw token counts
- Clear rootEl.textContent + set inline display style before empty state innerHTML to wipe any residual bar backgrounds
- Add position:relative to empty-state wrapper to prevent bleed-through
- Also handles edge case where API returns partial data with NaN pcts

**Self-test:** curl /api/usage → all zeros → empty state renders cleanly, no bar track visible